### PR TITLE
Update setup to central v11 config in new release, add pnet tau probs.

### DIFF
--- a/NanoProd/customiseNano.py
+++ b/NanoProd/customiseNano.py
@@ -44,10 +44,16 @@ def customise(process, skip_ak4_scores=False):
     process = nanoAOD_addDeepInfoAK4CHS(process, False, False, True)
     process = AddParticleNetAK4Scores(process, 'jetTable')
 
+  for coord in [ 'x', 'y', 'z' ]:
+    setattr(process.genParticleTable.variables, 'v' + coord,
+            Var(f'vertex().{coord}', float, precision=10,
+                doc=f'{coord} coordinate of the gen particle production vertex'))
+
   process.boostedTauTable.variables.dxy = Var("leadChargedHadrCand().dxy()", float,
     doc="d_{xy} of lead track with respect to PV, in cm (with sign)", precision=10)
   process.boostedTauTable.variables.dz = Var("leadChargedHadrCand().dz()", float,
     doc="d_{z} of lead track with respect to PV, in cm (with sign)", precision=14)
+
   return process
 
 

--- a/NanoProd/customiseNano.py
+++ b/NanoProd/customiseNano.py
@@ -57,7 +57,7 @@ def customise_pnet(process):
     """
     process = customise(process, skip_ak4_scores=True)
 
-    addAK8 = False
+    addAK8 = True
 
     pnetDiscriminatorsAK4 = []
 

--- a/NanoProd/customiseNano.py
+++ b/NanoProd/customiseNano.py
@@ -87,8 +87,8 @@ def customise_pnet(process):
     process.pfParticleNetAK4LastJetTags = boostedJetONNXJetTagsProducer.clone();
     process.pfParticleNetAK4LastJetTags.src = cms.InputTag("pfParticleNetAK4LastJetTagInfos");
     process.pfParticleNetAK4LastJetTags.flav_names = cms.vstring('probmu','probele','probtaup1h0p','probtaup1h1p','probtaup1h2p','probtaup3h0p','probtaup3h1p','probtaum1h0p','probtaum1h1p','probtaum1h2p','probtaum3h0p','probtaum3h1p','probb','probc','probuds','probg','ptcorr','ptreshigh','ptreslow');
-    process.pfParticleNetAK4LastJetTags.preprocess_json = cms.string('RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost/preprocess.json');
-    process.pfParticleNetAK4LastJetTags.model_path = cms.FileInPath('RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost/particle-net.onnx');
+    process.pfParticleNetAK4LastJetTags.preprocess_json = cms.string('Framework/NanoProd/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost/preprocess.json');
+    process.pfParticleNetAK4LastJetTags.model_path = cms.FileInPath('Framework/NanoProd/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost/particle-net.onnx');
     process.pfParticleNetAK4LastJetTags.debugMode = cms.untracked.bool(False)
 
     pnetDiscriminatorsAK4.extend([
@@ -182,8 +182,8 @@ def customise_pnet(process):
       process.pfParticleNetAK8LastJetTags = boostedJetONNXJetTagsProducer.clone();
       process.pfParticleNetAK8LastJetTags.src = cms.InputTag("pfParticleNetAK8LastJetTagInfos");
       process.pfParticleNetAK8LastJetTags.flav_names = cms.vstring('probHtt','probHtm','probHte','probHbb','probHcc','probHqq','probHgg','probQCD2hf','probQCD1hf','probQCD0hf','masscorr');
-      process.pfParticleNetAK8LastJetTags.preprocess_json = cms.string('RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/preprocess.json');
-      process.pfParticleNetAK8LastJetTags.model_path = cms.FileInPath('RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/particle-net.onnx');
+      process.pfParticleNetAK8LastJetTags.preprocess_json = cms.string('Framework/NanoProd/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/preprocess.json');
+      process.pfParticleNetAK8LastJetTags.model_path = cms.FileInPath('Framework/NanoProd/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/particle-net.onnx');
 
       pnetDiscriminatorsAK8.extend([
           "pfParticleNetAK8LastJetTags:probHtt",
@@ -223,8 +223,8 @@ def customise_pnet(process):
 
       process.pfParticleNetMassRegressionJetTags = boostedJetONNXJetTagsProducer.clone(
           src = 'pfParticleNetAK8JetTagInfos',
-          preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
-          model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx',
+          preprocess_json = 'Framework/NanoProd/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
+          model_path = 'Framework/NanoProd/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx',
           flav_names = ["mass"]
       )
 

--- a/NanoProd/customiseNano.py
+++ b/NanoProd/customiseNano.py
@@ -30,7 +30,7 @@ def nanoAOD_addDeepInfoAK4CHS(process, addDeepBTag, addDeepFlavour, addParticleN
   process.updatedJets.jetSource="selectedUpdatedPatJetsWithDeepInfo"
   return process
 
-def customise(process):
+def customise(process, skip_ak4_scores=False):
   process.MessageLogger.cerr.FwkReport.reportEvery = 100
   process.finalGenParticles.select = cms.vstring(
     "drop *",
@@ -40,11 +40,232 @@ def customise(process):
     "drop abs(pdgId)= 2212 && abs(pz) > 1000", #drop LHC protons accidentally added by previous keeps
   )
 
-  process = nanoAOD_addDeepInfoAK4CHS(process, False, False, True)
-  process = AddParticleNetAK4Scores(process, 'jetTable')
+  if not skip_ak4_scores:
+    process = nanoAOD_addDeepInfoAK4CHS(process, False, False, True)
+    process = AddParticleNetAK4Scores(process, 'jetTable')
 
   process.boostedTauTable.variables.dxy = Var("leadChargedHadrCand().dxy()", float,
     doc="d_{xy} of lead track with respect to PV, in cm (with sign)", precision=10)
   process.boostedTauTable.variables.dz = Var("leadChargedHadrCand().dz()", float,
     doc="d_{z} of lead track with respect to PV, in cm (with sign)", precision=14)
   return process
+
+
+def customise_pnet(process):
+    """
+    Blunt copy of https://github.com/cms-tau-pog/NanoProd/pull/10.
+    """
+    process = customise(process, skip_ak4_scores=True)
+
+    addAK8 = False
+
+    pnetDiscriminatorsAK4 = []
+
+    process.pfParticleNetAK4LastJetTagInfos = cms.EDProducer("ParticleNetFeatureEvaluator",
+        muons = cms.InputTag("slimmedMuons"),
+        electrons = cms.InputTag("slimmedElectrons"),
+        photons = cms.InputTag("slimmedPhotons"),
+        taus = cms.InputTag("slimmedTaus"),
+        vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+        secondary_vertices = cms.InputTag("slimmedSecondaryVertices"),
+        pf_candidates = cms.InputTag("packedPFCandidates"),
+        jets = cms.InputTag("updatedJetsWithUserData"),
+        losttracks = cms.InputTag("lostTracks"),
+        jet_radius = cms.double(0.4),
+        min_jet_pt = cms.double(20), # Default value
+        max_jet_eta = cms.double(2.5), # Default value
+        min_pt_for_pfcandidates = cms.double(0.1), # Default value
+        min_pt_for_track_properties = cms.double(-1),
+        min_pt_for_losttrack = cms.double(1.0), # Default value
+        max_dr_for_losttrack = cms.double(0.2), # Default value
+        min_pt_for_taus = cms.double(18), # Default value
+        max_eta_for_taus = cms.double(2.5),
+        dump_feature_tree = cms.bool(False)
+    )
+
+    from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+    process.pfParticleNetAK4LastJetTags = boostedJetONNXJetTagsProducer.clone();
+    process.pfParticleNetAK4LastJetTags.src = cms.InputTag("pfParticleNetAK4LastJetTagInfos");
+    process.pfParticleNetAK4LastJetTags.flav_names = cms.vstring('probmu','probele','probtaup1h0p','probtaup1h1p','probtaup1h2p','probtaup3h0p','probtaup3h1p','probtaum1h0p','probtaum1h1p','probtaum1h2p','probtaum3h0p','probtaum3h1p','probb','probc','probuds','probg','ptcorr','ptreshigh','ptreslow');
+    process.pfParticleNetAK4LastJetTags.preprocess_json = cms.string('RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost/preprocess.json');
+    process.pfParticleNetAK4LastJetTags.model_path = cms.FileInPath('RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost/particle-net.onnx');
+    process.pfParticleNetAK4LastJetTags.debugMode = cms.untracked.bool(False)
+
+    pnetDiscriminatorsAK4.extend([
+        "pfParticleNetAK4LastJetTags:probmu",
+        "pfParticleNetAK4LastJetTags:probele",
+        "pfParticleNetAK4LastJetTags:probtaup1h0p",
+        "pfParticleNetAK4LastJetTags:probtaup1h1p",
+        "pfParticleNetAK4LastJetTags:probtaup1h2p",
+        "pfParticleNetAK4LastJetTags:probtaup3h0p",
+        "pfParticleNetAK4LastJetTags:probtaup3h1p",
+        "pfParticleNetAK4LastJetTags:probtaum1h0p",
+        "pfParticleNetAK4LastJetTags:probtaum1h1p",
+        "pfParticleNetAK4LastJetTags:probtaum1h2p",
+        "pfParticleNetAK4LastJetTags:probtaum3h0p",
+        "pfParticleNetAK4LastJetTags:probtaum3h1p",
+        "pfParticleNetAK4LastJetTags:probb",
+        "pfParticleNetAK4LastJetTags:probc",
+        "pfParticleNetAK4LastJetTags:probuds",
+        "pfParticleNetAK4LastJetTags:probg",
+        "pfParticleNetAK4LastJetTags:ptcorr",
+        "pfParticleNetAK4LastJetTags:ptreslow",
+        "pfParticleNetAK4LastJetTags:ptreshigh",
+    ])
+
+    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cfi import updatedPatJets
+    process.slimmedJetsUpdatedPNET = updatedPatJets.clone(
+        jetSource = "updatedJetsWithUserData",
+        addJetCorrFactors = False,
+        discriminatorSources = pnetDiscriminatorsAK4
+    )
+
+    from RecoJets.JetProducers.PileupJetID_cfi import _chsalgos_106X_UL18, pileupJetId
+    process.pileupJetIdUpdatedPNET = pileupJetId.clone(
+        jets = cms.InputTag("updatedJetsWithUserData"),
+        inputIsCorrected = True,
+        applyJec = False,
+        vertexes = cms.InputTag("offlineSlimmedPrimaryVertices"),
+        algos = cms.VPSet(_chsalgos_106X_UL18),
+    )
+
+    process.slimmedJetsUpdatedPNET.userData.userInts.src += ['pileupJetIdUpdatedPNET:fullId'];
+
+    from PhysicsTools.NanoAOD.common_cff import Var
+    process.finalJets.src = cms.InputTag("slimmedJetsUpdatedPNET")
+    process.jetTable.variables.PNET_taup1h0p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaup1h0p')",float,precision=10)
+    process.jetTable.variables.PNET_taup1h1p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaup1h1p')",float,precision=10)
+    process.jetTable.variables.PNET_taup1h2p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaup1h2p')",float,precision=10)
+    process.jetTable.variables.PNET_taup3h0p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaup3h0p')",float,precision=10)
+    process.jetTable.variables.PNET_taup3h1p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaup3h1p')",float,precision=10)
+    process.jetTable.variables.PNET_taum1h0p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaum1h0p')",float,precision=10)
+    process.jetTable.variables.PNET_taum1h1p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaum1h1p')",float,precision=10)
+    process.jetTable.variables.PNET_taum1h2p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaum1h2p')",float,precision=10)
+    process.jetTable.variables.PNET_taum3h0p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaum3h0p')",float,precision=10)
+    process.jetTable.variables.PNET_taum3h1p = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probtaum3h1p')",float,precision=10)
+    process.jetTable.variables.PNET_mu = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probmu')",float,precision=10)
+    process.jetTable.variables.PNET_ele = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probele')",float,precision=10)
+    process.jetTable.variables.PNET_b = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probb')",float,precision=10)
+    process.jetTable.variables.PNET_c = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probc')",float,precision=10)
+    process.jetTable.variables.PNET_uds = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probuds')",float,precision=10)
+    process.jetTable.variables.PNET_g = Var("bDiscriminator('pfParticleNetAK4LastJetTags:probg')",float,precision=10)
+    process.jetTable.variables.PNET_ptcorr = Var("bDiscriminator('pfParticleNetAK4LastJetTags:ptcorr')",float,precision=10)
+    process.jetTable.variables.PNET_ptreslow = Var("bDiscriminator('pfParticleNetAK4LastJetTags:ptreslow')",float,precision=10)
+    process.jetTable.variables.PNET_ptreshigh = Var("bDiscriminator('pfParticleNetAK4LastJetTags:ptreshigh')",float,precision=10)
+
+    process.edTask = cms.Task()
+    process.edTask.add(getattr(process,"slimmedJetsUpdatedPNET"))
+    process.edTask.add(getattr(process,"pileupJetIdUpdatedPNET"))
+    process.edTask.add(getattr(process,"pfParticleNetAK4LastJetTags"))
+    process.edTask.add(getattr(process,"pfParticleNetAK4LastJetTagInfos"))
+
+
+    if addAK8:
+      pnetDiscriminatorsAK8 = []
+
+      process.pfParticleNetAK8LastJetTagInfos = cms.EDProducer("ParticleNetFeatureEvaluator",
+          vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+          secondary_vertices = cms.InputTag("slimmedSecondaryVertices"),
+          pf_candidates = cms.InputTag("packedPFCandidates"),
+          jets = cms.InputTag("updatedJetsAK8WithUserData"),
+          muons = cms.InputTag("slimmedMuons"),
+          electrons = cms.InputTag("slimmedElectrons"),
+          taus = cms.InputTag("slimmedTaus"),
+          jet_radius = cms.double(0.8),
+          min_jet_pt = cms.double(200), # Default value
+          max_jet_eta = cms.double(2.5), # Default value
+          min_pt_for_pfcandidates = cms.double(0.1), # Default value
+          use_puppiP4 = cms.bool(False),
+          min_puppi_wgt = cms.double(-1),
+      )
+
+      process.pfParticleNetAK8LastJetTags = boostedJetONNXJetTagsProducer.clone();
+      process.pfParticleNetAK8LastJetTags.src = cms.InputTag("pfParticleNetAK8LastJetTagInfos");
+      process.pfParticleNetAK8LastJetTags.flav_names = cms.vstring('probHtt','probHtm','probHte','probHbb','probHcc','probHqq','probHgg','probQCD2hf','probQCD1hf','probQCD0hf','masscorr');
+      process.pfParticleNetAK8LastJetTags.preprocess_json = cms.string('RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/preprocess.json');
+      process.pfParticleNetAK8LastJetTags.model_path = cms.FileInPath('RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/particle-net.onnx');
+
+      pnetDiscriminatorsAK8.extend([
+          "pfParticleNetAK8LastJetTags:probHtt",
+          "pfParticleNetAK8LastJetTags:probHtm",
+          "pfParticleNetAK8LastJetTags:probHte",
+          "pfParticleNetAK8LastJetTags:probHbb",
+          "pfParticleNetAK8LastJetTags:probHcc",
+          "pfParticleNetAK8LastJetTags:probHqq",
+          "pfParticleNetAK8LastJetTags:probHgg",
+          "pfParticleNetAK8LastJetTags:probQCD2hf",
+          "pfParticleNetAK8LastJetTags:probQCD1hf",
+          "pfParticleNetAK8LastJetTags:probQCD0hf",
+          "pfParticleNetAK8LastJetTags:masscorr"
+      ])
+
+      process.slimmedJetsAK8UpdatedPNET = updatedPatJets.clone(
+          jetSource = "updatedJetsAK8WithUserData",
+          addJetCorrFactors = False,
+          discriminatorSources = pnetDiscriminatorsAK8
+      )
+
+      from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
+      process.pfParticleNetAK8JetTagInfos = pfDeepBoostedJetTagInfos.clone(
+         jet_radius = 0.8,
+          min_pt_for_track_properties = 0.95,
+          min_jet_pt = 200, # Default value
+          max_jet_eta = 2.5, # Default value
+          use_puppiP4 = False,
+          min_puppi_wgt = -1,
+          vertices = "offlineSlimmedPrimaryVertices",
+          secondary_vertices = "slimmedSecondaryVertices",
+          pf_candidates = "packedPFCandidates",
+          jets = "updatedJetsAK8WithUserData",
+          puppi_value_map = "",
+          vertex_associator = ""
+      )
+
+      process.pfParticleNetMassRegressionJetTags = boostedJetONNXJetTagsProducer.clone(
+          src = 'pfParticleNetAK8JetTagInfos',
+          preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
+          model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx',
+          flav_names = ["mass"]
+      )
+
+      process.slimmedJetsAK8UpdatedPNET.discriminatorSources.extend(["pfParticleNetMassRegressionJetTags:mass"])
+
+      process.finalJetsAK8.src = cms.InputTag("slimmedJetsAK8UpdatedPNET")
+      process.lepInAK8JetVars.src = cms.InputTag("slimmedJetsAK8UpdatedPNET")
+      process.fatJetTable.variables.PNET_Htt = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHtt')",float,precision=10)
+      process.fatJetTable.variables.PNET_Htm = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHtm')",float,precision=10)
+      process.fatJetTable.variables.PNET_Hte = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHte')",float,precision=10)
+      process.fatJetTable.variables.PNET_Hbb = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHbb')",float,precision=10)
+      process.fatJetTable.variables.PNET_Hcc = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHcc')",float,precision=10)
+      process.fatJetTable.variables.PNET_Hqq = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHqq')",float,precision=10)
+      process.fatJetTable.variables.PNET_Hgg = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probHgg')",float,precision=10)
+      process.fatJetTable.variables.PNET_QCD2hf = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probQCD2hf')",float,precision=10)
+      process.fatJetTable.variables.PNET_QCD1hf = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probQCD1hf')",float,precision=10)
+      process.fatJetTable.variables.PNET_QCD0hf = Var("bDiscriminator('pfParticleNetAK8LastJetTags:probQCD0hf')",float,precision=10)
+      process.fatJetTable.variables.PNET_masscorr = Var("bDiscriminator('pfParticleNetAK8LastJetTags:masscorr')",float,precision=10)
+      process.fatJetTable.variables.PNET_massregression = Var("bDiscriminator('pfParticleNetMassRegressionJetTags:mass')",float,precision=10)
+
+      process.edTask.add(getattr(process,"slimmedJetsAK8UpdatedPNET"))
+      process.edTask.add(getattr(process,"pfParticleNetAK8JetTagInfos"))
+      process.edTask.add(getattr(process,"pfParticleNetMassRegressionJetTags"))
+      process.edTask.add(getattr(process,"pfParticleNetAK8LastJetTags"))
+      process.edTask.add(getattr(process,"pfParticleNetAK8LastJetTagInfos"))
+
+    # For some reason these are lost when integrated as customization (even when not processing AK8), so re-add them to path.
+    #process.edTask.add(getattr(process,"updatedPatJetsAK8WithDeepInfo"))
+    #process.edTask.add(getattr(process,"selectedUpdatedPatJetsAK8WithDeepInfo"))
+    #process.edTask.add(getattr(process,"updatedPatJetsTransientCorrectedAK8WithDeepInfo"))
+    #process.edTask.add(getattr(process,"patJetCorrFactorsTransientCorrectedAK8WithDeepInfo"))
+    #process.edTask.add(getattr(process,"pfParticleNetTagInfosAK8WithDeepInfo"))
+    #process.edTask.add(getattr(process,"pfParticleNetMassRegressionJetTagsAK8WithDeepInfo"))
+    #process.edTask.add(getattr(process,"patJetCorrFactorsAK8WithDeepInfo"))
+    for key in process.__dict__.keys():
+        if(type(getattr(process,key)).__name__=='EDProducer' or type(getattr(process,key)).__name__=='EDFilter') and "AK8WithDeepInfo" in key:
+            process.edTask.add(getattr(process,key))
+
+    process.edPath = cms.Path(process.edTask)
+
+    # Schedule definition
+    process.schedule = cms.Schedule(process.edPath,process.nanoAOD_step,process.endjob_step,process.NANOAODSIMoutput_step)
+
+    return process

--- a/config/overseer_cfg.yaml
+++ b/config/overseer_cfg.yaml
@@ -1,6 +1,6 @@
 cmsswPython: RunKit/nanoProdWrapper.py
 params:
-  customise: Framework/NanoProd/customiseNano.customise
+  customise: Framework/NanoProd/customiseNano.customise_pnet
   skimCfg: skim.yaml
   maxEvents: -1
 splitting: FileBased

--- a/env.sh
+++ b/env.sh
@@ -48,21 +48,22 @@ action() {
         run_cmd scramv1 project CMSSW $CMSSW_VER
         run_cmd cd $CMSSW_VER/src
         run_cmd eval `scramv1 runtime -sh`
-        run_cmd git-cms-init
-        run_cmd git cms-addpkg RecoBTag/Combined
+        # clone repos
         run_cmd git clone ssh://git@gitlab.cern.ch:7999/akhukhun/roccor.git RoccoR
         run_cmd git clone git@github.com:SVfit/ClassicSVfit.git TauAnalysis/ClassicSVfit -b fastMTT_19_02_2019
         run_cmd git clone git@github.com:SVfit/SVfitTF.git TauAnalysis/SVfitTF
         run_cmd git clone ssh://git@gitlab.cern.ch:7999/rgerosa/particlenetstudiesrun2.git ParticleNetStudiesRun2 -b cmssw_126X
         run_cmd git clone git@github.com:cms-data/RecoBTag-Combined.git recobtag_data
-        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL
-        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/
-        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg
-        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/* RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/
-        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01
-        run_cmd cp recobtag_data/ParticleNetAK8/MassRegression/V01/modelfile/model.onnx RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx
+        # copy model files
+        run_cmd mkdir -p Framework/NanoProd/data/ParticleNetAK4/CHS/PNETUL
+        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost Framework/NanoProd/data/ParticleNetAK4/CHS/PNETUL/
+        run_cmd mkdir -p Framework/NanoProd/data/ParticleNetAK8/Puppi/PNETUL/ClassReg
+        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/* Framework/NanoProd/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/
+        run_cmd mkdir -p Framework/NanoProd/data/ParticleNetAK8/MassRegression/V01
+        run_cmd cp recobtag_data/ParticleNetAK8/MassRegression/V01/modelfile/model.onnx Framework/NanoProd/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx
+        run_cmd cp recobtag_data/ParticleNetAK8/MassRegression/V01/*.json Framework/NanoProd/data/ParticleNetAK8/MassRegression/V01/
         run_cmd rm -rf recobtag_data
-        run_cmd mkdir -p Framework/NanoProd/
+        # link framework files into release
         run_cmd ln -s "$this_dir/NanoProd" Framework/NanoProd/python
         run_cmd mkdir -p HHTools
         run_cmd ln -s "$this_dir/HHbtag" HHTools/HHbtag
@@ -83,6 +84,7 @@ action() {
         # end of workaround
         run_cmd cd "$this_dir"
         run_cmd mkdir -p "$this_dir/soft/CentOS$os_version/bin"
+        run_cmd rm -f "$this_dir/soft/CentOS$os_version/bin/python"
         run_cmd ln -s $(which python3) "$this_dir/soft/CentOS$os_version/bin/python"
         run_cmd touch "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed"
     else

--- a/env.sh
+++ b/env.sh
@@ -35,7 +35,7 @@ action() {
     else
         export SCRAM_ARCH=el8_amd64_gcc10
     fi
-    CMSSW_VER=CMSSW_12_4_8
+    CMSSW_VER=CMSSW_12_6_0_patch1
     if ! [ -f "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed" ]; then
         run_cmd mkdir -p "$this_dir/soft/CentOS$os_version"
         run_cmd cd "$this_dir/soft/CentOS$os_version"
@@ -48,11 +48,19 @@ action() {
         run_cmd scramv1 project CMSSW $CMSSW_VER
         run_cmd cd $CMSSW_VER/src
         run_cmd eval `scramv1 runtime -sh`
+        run_cmd git-cms-init
+        run_cmd git clone ssh://git@gitlab.cern.ch:7999/akhukhun/roccor.git RoccoR
+        run_cmd git clone git@github.com:SVfit/ClassicSVfit.git TauAnalysis/ClassicSVfit -b fastMTT_19_02_2019
+        run_cmd git clone git@github.com:SVfit/SVfitTF.git TauAnalysis/SVfitTF
+        run_cmd git clone ssh://git@gitlab.cern.ch:7999/rgerosa/particlenetstudiesrun2.git ParticleNetStudiesRun2 -b cmssw_126X
+        run_cmd git cms-addpkg RecoBTag/Combined
+        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL
+        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/
         run_cmd mkdir -p Framework/NanoProd/
-        run_cmd ln -s "$this_dir/NanoProd" Framework/NanoProd/python  
+        run_cmd ln -s "$this_dir/NanoProd" Framework/NanoProd/python
         run_cmd mkdir -p HHTools
         run_cmd ln -s "$this_dir/HHbtag" HHTools/HHbtag
-        run_cmd scram b -j8 
+        run_cmd scram b -j8
         run_cmd cd "$this_dir"
         run_cmd mkdir -p "$this_dir/soft/CentOS$os_version/bin"
         run_cmd ln -s $(which python3) "$this_dir/soft/CentOS$os_version/bin/python"

--- a/env.sh
+++ b/env.sh
@@ -67,6 +67,20 @@ action() {
         run_cmd mkdir -p HHTools
         run_cmd ln -s "$this_dir/HHbtag" HHTools/HHbtag
         run_cmd scram b -j8
+        # workaround for CMSSW - CRAB compatibility
+        # since recently, "scram b" does not link files into the python directory any longer and
+        # therefore, crab's bundling of the python directory will miss all files (for now), so below,
+        # create symlinks manually that are picked up through dereferencing during crab job bundling
+        run_cmd touch ../python/__init__.py
+        for n in */*/python; do
+            subsys="$( echo ${n} | awk -F '/' '{print $1}' )"
+            mod="$( echo ${n} | awk -F '/' '{print $2}' )"
+            run_cmd mkdir -p "../python/${subsys}"
+            run_cmd rm -rf "../python/${subsys}/${mod}"
+            run_cmd ln -s "../../src/${subsys}/${mod}/python" "../python/${subsys}/${mod}"
+            run_cmd touch "../python/${subsys}/__init__.py" "../python/${subsys}/${mod}/__init__.py"
+        done
+        # end of workaround
         run_cmd cd "$this_dir"
         run_cmd mkdir -p "$this_dir/soft/CentOS$os_version/bin"
         run_cmd ln -s $(which python3) "$this_dir/soft/CentOS$os_version/bin/python"

--- a/env.sh
+++ b/env.sh
@@ -49,13 +49,19 @@ action() {
         run_cmd cd $CMSSW_VER/src
         run_cmd eval `scramv1 runtime -sh`
         run_cmd git-cms-init
+        run_cmd git cms-addpkg RecoBTag/Combined
         run_cmd git clone ssh://git@gitlab.cern.ch:7999/akhukhun/roccor.git RoccoR
         run_cmd git clone git@github.com:SVfit/ClassicSVfit.git TauAnalysis/ClassicSVfit -b fastMTT_19_02_2019
         run_cmd git clone git@github.com:SVfit/SVfitTF.git TauAnalysis/SVfitTF
         run_cmd git clone ssh://git@gitlab.cern.ch:7999/rgerosa/particlenetstudiesrun2.git ParticleNetStudiesRun2 -b cmssw_126X
-        run_cmd git cms-addpkg RecoBTag/Combined
+        run_cmd git clone git@github.com:cms-data/RecoBTag-Combined.git recobtag_data
         run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL
         run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK4/data/ParticleNetAK4/CHS/PNETUL/ClassRegQuantileNoJECLost RecoBTag/Combined/data/ParticleNetAK4/CHS/PNETUL/
+        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg
+        run_cmd cp -r ParticleNetStudiesRun2/TrainingNtupleMakerAK8/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/* RecoBTag/Combined/data/ParticleNetAK8/Puppi/PNETUL/ClassReg/
+        run_cmd mkdir -p RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01
+        run_cmd cp recobtag_data/ParticleNetAK8/MassRegression/V01/modelfile/model.onnx RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx
+        run_cmd rm -rf recobtag_data
         run_cmd mkdir -p Framework/NanoProd/
         run_cmd ln -s "$this_dir/NanoProd" Framework/NanoProd/python
         run_cmd mkdir -p HHTools
@@ -64,7 +70,7 @@ action() {
         run_cmd cd "$this_dir"
         run_cmd mkdir -p "$this_dir/soft/CentOS$os_version/bin"
         run_cmd ln -s $(which python3) "$this_dir/soft/CentOS$os_version/bin/python"
-        touch "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed"
+        run_cmd touch "$this_dir/soft/CentOS$os_version/$CMSSW_VER/.installed"
     else
         run_cmd cd "$this_dir/soft/CentOS$os_version/$CMSSW_VER/src"
         run_cmd eval `scramv1 runtime -sh`


### PR DESCRIPTION
This PR updates the setup to

- use the `12_6_0_patch1` release containing the official v11 config published today, and
- includes the particle net outputs for tau probabilities.

The latter is a blunt copy of https://github.com/cms-tau-pog/NanoProd/pull/10 with one minor change: it uses the `cmssw_126x` branch of the https://gitlab.cern.ch/rgerosa/particlenetstudiesrun2 project, rather than `cmssw_124x` which Raffaele deleted today. It appears that he is still actively working on the `cmssw_126x` branch 😀, but things already run nicely.

*edit* I flagged this as draft for the moment due to two residual todos / issues:

- [x] Add and test PNet taggers for AK8
- [x] Crab jobs fail due to a missing data for in RecoBTag